### PR TITLE
Floating hint now shows for Material and Metro PasswordBox

### DIFF
--- a/src/MaterialForms/Themes/Material.xaml
+++ b/src/MaterialForms/Themes/Material.xaml
@@ -7,6 +7,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Material/Field.CheckBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Material/Field.Converted.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Material/Field.String.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Material/Field.Password.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Material/Field.DatePicker.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Material/Field.Switch.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Material/Field.Selection.xaml" />
@@ -16,18 +17,16 @@
     </ResourceDictionary.MergedDictionaries>
 
     <Style BasedOn="{StaticResource MaterialStringPresenterStyle}" TargetType="{x:Type defaults:StringPresenter}" />
+    <Style BasedOn="{StaticResource MaterialPasswordPresenterStyle}" TargetType="{x:Type defaults:PasswordPresenter}" />
     <Style BasedOn="{StaticResource MaterialConvertedPresenterStyle}" TargetType="{x:Type defaults:ConvertedPresenter}" />
     <Style BasedOn="{StaticResource MaterialCheckBoxPresenterStyle}" TargetType="{x:Type defaults:CheckBoxPresenter}" />
     <Style BasedOn="{StaticResource MaterialSwitchPresenterStyle}" TargetType="{x:Type defaults:SwitchPresenter}" />
     <Style BasedOn="{StaticResource MaterialSelectionPresenterStyle}" TargetType="{x:Type defaults:SelectionPresenter}" />
     <Style BasedOn="{StaticResource MaterialSliderPresenterStyle}" TargetType="{x:Type defaults:SliderPresenter}" />
-
     <Style BasedOn="{StaticResource MaterialTitlePresenterStyle}" TargetType="{x:Type defaults:TitlePresenter}" />
     <Style BasedOn="{StaticResource MaterialHeadingPresenterStyle}" TargetType="{x:Type defaults:HeadingPresenter}" />
     <Style BasedOn="{StaticResource MaterialTextPresenterStyle}" TargetType="{x:Type defaults:TextPresenter}" />
-
     <Style BasedOn="{StaticResource MaterialActionPresenterStyle}" TargetType="{x:Type defaults:ActionPresenter}" />
-
     <Style BasedOn="{StaticResource MaterialDatePickerPresenterStyle}" TargetType="{x:Type defaults:DatePresenter}" />
 
 </ResourceDictionary>

--- a/src/MaterialForms/Themes/Material/Field.Password.xaml
+++ b/src/MaterialForms/Themes/Material/Field.Password.xaml
@@ -33,7 +33,6 @@
                 Grid.Column="1"
                 Margin="0,-14,0,0"
                 VerticalAlignment="Center"
-                attachedProperties:PasswordBoxHelper.Password="{fields:FormBinding Value}"
                 controls1:SelectTextOnFocus.Active="{fields:FormBinding SelectOnFocus}"
                 materialDesign:HintAssist.Hint="{fields:FormBinding Name}"
                 Style="{StaticResource MaterialDesignFloatingHintPasswordBox}"

--- a/src/MaterialForms/Themes/Material/Field.Password.xaml
+++ b/src/MaterialForms/Themes/Material/Field.Password.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:attachedProperties="clr-namespace:MaterialForms.AttachedProperties"
     xmlns:controls1="clr-namespace:MaterialForms.Wpf.Controls"
     xmlns:defaults="clr-namespace:MaterialForms.Wpf.Fields.Defaults"
     xmlns:fields="clr-namespace:MaterialForms.Wpf.Fields"
@@ -9,7 +10,7 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Material/IconStyles.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.PasswordBox.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <ControlTemplate x:Key="MaterialPasswordPresenterTemplate" TargetType="{x:Type defaults:PasswordPresenter}">
@@ -33,9 +34,10 @@
                 Grid.Column="1"
                 Margin="0,-14,0,0"
                 VerticalAlignment="Center"
+                attachedProperties:PasswordBoxHelper.Password="{fields:FormBinding Value}"
                 controls1:SelectTextOnFocus.Active="{fields:FormBinding SelectOnFocus}"
                 materialDesign:HintAssist.Hint="{fields:FormBinding Name}"
-                Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                Style="{StaticResource MaterialDesignFloatingHintPasswordBox}"
                 attachedProperties:PasswordBoxHelper.Password="{fields:FormBinding Value}"
                 ToolTip="{fields:FormBinding ToolTip}" />
         </Grid>

--- a/src/MaterialForms/Themes/Material/Field.Password.xaml
+++ b/src/MaterialForms/Themes/Material/Field.Password.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:attachedProperties="clr-namespace:MaterialForms.AttachedProperties"
     xmlns:controls1="clr-namespace:MaterialForms.Wpf.Controls"
     xmlns:defaults="clr-namespace:MaterialForms.Wpf.Fields.Defaults"
     xmlns:fields="clr-namespace:MaterialForms.Wpf.Fields"

--- a/src/MaterialForms/Themes/Metro.xaml
+++ b/src/MaterialForms/Themes/Metro.xaml
@@ -8,12 +8,14 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Metro/Field.CheckBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Metro/Field.Converted.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Metro/Field.String.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Metro/Field.Password.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Metro/Field.Switch.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Metro/Element.Text.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Metro/Element.Action.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style BasedOn="{StaticResource MetroStringPresenterStyle}" TargetType="{x:Type defaults:StringPresenter}" />
+    <Style BasedOn="{StaticResource MetroPasswordPresenterStyle}" TargetType="{x:Type defaults:PasswordPresenter}" />
     <Style BasedOn="{StaticResource MetroConvertedPresenterStyle}" TargetType="{x:Type defaults:ConvertedPresenter}" />
     <Style BasedOn="{StaticResource MetroCheckBoxPresenterStyle}" TargetType="{x:Type defaults:CheckBoxPresenter}" />
     <Style BasedOn="{StaticResource MetroSwitchPresenterStyle}" TargetType="{x:Type defaults:SwitchPresenter}" />

--- a/src/MaterialForms/Themes/Metro/Field.Password.xaml
+++ b/src/MaterialForms/Themes/Metro/Field.Password.xaml
@@ -32,7 +32,6 @@
                 Name="ValueHolderControl"
                 Grid.Column="1"
                 VerticalAlignment="Center"
-                attachedProperties:PasswordBoxHelper.Password="{fields:FormBinding Value}"
                 controls:TextBoxHelper.SelectAllOnFocus="{fields:FormBinding SelectOnFocus}"
                 controls:TextBoxHelper.UseFloatingWatermark="True"
                 controls:TextBoxHelper.Watermark="{fields:FormBinding Name}"

--- a/src/MaterialForms/Themes/Metro/Field.Password.xaml
+++ b/src/MaterialForms/Themes/Metro/Field.Password.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:attachedProperties="clr-namespace:MaterialForms.AttachedProperties"
     xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
     xmlns:defaults="clr-namespace:MaterialForms.Wpf.Fields.Defaults"
     xmlns:fields="clr-namespace:MaterialForms.Wpf.Fields"
@@ -9,7 +10,7 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MaterialForms;component/Themes/Metro/IconStyles.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Textbox.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.PasswordBox.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <ControlTemplate x:Key="MetroPasswordPresenterTemplate" TargetType="{x:Type defaults:PasswordPresenter}">
@@ -32,11 +33,12 @@
                 Name="ValueHolderControl"
                 Grid.Column="1"
                 VerticalAlignment="Center"
+                attachedProperties:PasswordBoxHelper.Password="{fields:FormBinding Value}"
                 controls:TextBoxHelper.SelectAllOnFocus="{fields:FormBinding SelectOnFocus}"
                 controls:TextBoxHelper.UseFloatingWatermark="True"
                 controls:TextBoxHelper.Watermark="{fields:FormBinding Name}"
                 FontSize="{TemplateBinding FontSize}"
-                Style="{StaticResource MetroTextBox}"
+                Style="{StaticResource MetroPasswordBox}"
                 attachedProperties:PasswordBoxHelper.Password="{fields:FormBinding Value}"
                 ToolTip="{fields:FormBinding ToolTip}" />
         </Grid>

--- a/src/MaterialForms/Themes/Metro/Field.Password.xaml
+++ b/src/MaterialForms/Themes/Metro/Field.Password.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:attachedProperties="clr-namespace:MaterialForms.AttachedProperties"
     xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
     xmlns:defaults="clr-namespace:MaterialForms.Wpf.Fields.Defaults"
     xmlns:fields="clr-namespace:MaterialForms.Wpf.Fields"


### PR DESCRIPTION
Something I noticed while playing with the recent changes that introduced the PasswordBox field.